### PR TITLE
fix: renderMatrix2d not pixel perfect

### DIFF
--- a/src/tbgl_Fonts.inc
+++ b/src/tbgl_Fonts.inc
@@ -241,25 +241,25 @@ SUB Exec_TBGL_PrintFont2D( )
     ' X
     SELECT CASE AS LONG (screenAlignment)
       CASE %TBGL_ALIGN_LEFT, %TBGL_ALIGN_LEFT_UP, %TBGL_ALIGN_LEFT_CENTER, %TBGL_ALIGN_LEFT_DOWN
-        x += rm2D_Left
+        x += g_renderMatrix2D.Left
 
       CASE %TBGL_ALIGN_CENTER, %TBGL_ALIGN_CENTER_UP, %TBGL_ALIGN_CENTER_CENTER, %TBGL_ALIGN_CENTER_DOWN
-        x += rm2D_Left+(rm2D_Right - rm2D_Left)/2
+        x += g_renderMatrix2D.left+(g_renderMatrix2D.right - g_renderMatrix2D.left)/2
 
       CASE %TBGL_ALIGN_RIGHT, %TBGL_ALIGN_RIGHT_UP, %TBGL_ALIGN_RIGHT_CENTER, %TBGL_ALIGN_RIGHT_DOWN
-        x += rm2D_Right
+        x += g_renderMatrix2D.right
     END SELECT
 
     ' Y
     SELECT CASE AS LONG (screenAlignment)
       CASE %TBGL_ALIGN_LEFT_UP, %TBGL_ALIGN_CENTER_UP, %TBGL_ALIGN_RIGHT_UP
-        y += rm2D_Top
+        y += g_renderMatrix2D.top
 
       CASE %TBGL_ALIGN_LEFT_CENTER, %TBGL_ALIGN_CENTER_CENTER, %TBGL_ALIGN_RIGHT_CENTER
-        y += rm2D_Top+(rm2D_Bottom - rm2D_Top)/2
+        y += g_renderMatrix2D.top+(g_renderMatrix2D.bottom - g_renderMatrix2D.top)/2
 
       CASE %TBGL_ALIGN_LEFT_DOWN, %TBGL_ALIGN_CENTER_DOWN, %TBGL_ALIGN_RIGHT_DOWN
-        y += rm2D_Bottom
+        y += g_renderMatrix2D.bottom
     END SELECT
 
   END IF
@@ -699,7 +699,7 @@ END SUB
 
 SUB internal_ManagedRasterPos(BYVAL x AS SINGLE, BYVAL y AS SINGLE, BYVAL z AS SINGLE)
 
-  IF rm2D_Top < rm2D_Bottom THEN y = ABS(rm2D_Bottom-rm2D_Top) - y
+  IF g_renderMatrix2D.top < g_renderMatrix2D.bottom THEN y = ABS(g_renderMatrix2D.bottom-g_renderMatrix2D.top) - y
 
   glPushAttrib(%GL_TRANSFORM_BIT OR %GL_VIEWPORT_BIT)
 

--- a/src/tbgl_Frame.inc
+++ b/src/tbgl_Frame.inc
@@ -27,6 +27,28 @@ GLOBAL dDivisor AS QUAD
 
 ' -----------------------------------------------------------------------------
 
+%TBGL_OPENGL_ORTHO_2D  = 0
+%TBGL_PIXEL_PERFECT_2D = 1
+
+type tRenderMatrix2D
+  pixelPerfect as long
+  pixelOffsetX as single
+  pixelOffsetY as single
+
+  left         as single
+  right        as single
+  top          as single
+  bottom       as single
+end type
+
+global g_renderMatrix2D as tRenderMatrix2D
+
+sub resource_Frame_Init()
+  reset g_renderMatrix2D
+end sub
+
+' -----------------------------------------------------------------------------
+
 ' -- Clears specified buffers and can reset matrix
 SUB Exec_TBGL_ClearFrame( )
 
@@ -108,31 +130,53 @@ END SUB
 
 
 ' -- Sets 2D mode, can have custom coordinate system
-%TBGL_OPENGL_ORTHO_2D  = 0
-%TBGL_PIXEL_PERFECT_2D = 1
+sub Exec_TBGL_RenderMatrix2D( )
+  local minx, miny, maxy, maxx, mode2d as ext
 
-GLOBAL rm2D_Left, rm2D_Right, rm2D_Top, rm2D_Bottom AS SINGLE
-SUB Exec_TBGL_RenderMatrix2D( )
-  LOCAL minx, miny, maxy, maxx AS EXT
+  mode2d = %TBGL_OPENGL_ORTHO_2D
 
-  IF thinBasic_CheckOpenParens_Optional THEN
+  if thinBasic_CheckOpenParens_Optional then
     thinBasic_ParseNumber minx
-    IF thinBasic_CheckComma_Mandatory( ) THEN
+    if thinBasic_CheckComma_Mandatory( ) then
       thinBasic_ParseNumber miny
-      IF thinBasic_CheckComma_Mandatory( ) THEN
+      if thinBasic_CheckComma_Mandatory( ) then
         thinBasic_ParseNumber maxx
-        IF thinBasic_CheckComma_Mandatory( ) THEN
+        if thinBasic_CheckComma_Mandatory( ) then
           thinBasic_ParseNumber maxy
+
+          if thinBasic_CheckComma_Optional( ) then
+            thinBasic_ParseNumber mode2d
+          end if
 
           thinBasic_CheckCloseParens_Mandatory
 
-        END IF
-      END IF
-    END IF
+          ' -- This overrides default off-by-one OpenGL rasterization via simple hack
+          g_renderMatrix2d.pixelPerfect = mode2d
+          if mode2d = %TBGL_PIXEL_PERFECT_2D then
+            if minx < maxx then
+              incr maxx
+              g_renderMatrix2d.pixelOffsetX = 0.5
+            else
+              decr maxx
+              g_renderMatrix2d.pixelOffsetX =-0.5
+            end if
 
-  ELSE
+            if miny < maxy then
+              incr maxy
+              g_renderMatrix2d.pixelOffsetY = 0.5
+            else
+              decr maxy
+              g_renderMatrix2d.pixelOffsetY =-0.5
+            end if
+          end if
 
-    LOCAL c AS RECT
+        end if
+      end if
+    end if
+
+  else
+
+    local c as RECT
     GetClientRect( g_Win.handle, c )
 
     minx = 0
@@ -140,24 +184,24 @@ SUB Exec_TBGL_RenderMatrix2D( )
     maxx = c.nRight
     maxy = c.nBottom
 
-  END IF
+  end if
 
   glLoadIdentity( )
   glMatrixMode( %GL_PROJECTION )
 
   glLoadIdentity( )
-  glOrtho(minx, maxx, miny, maxy, -1, 1)
+  glOrtho(minx-g_renderMatrix2d.pixelOffsetX, maxx-g_renderMatrix2d.pixelOffsetX, miny-g_renderMatrix2d.pixelOffsetY, maxy-g_renderMatrix2d.pixelOffsetY, 0, 1)
   glMatrixMode( %GL_MODELVIEW )
 
   g_Win.RenderMatrixMode = %TBGL_2D
 
-  '[!] Dirty, dirty, dirty coding...
-  rm2D_Left   = minX
-  rm2D_Bottom = minY
-  rm2D_Right  = maxX
-  rm2D_Top    = maxY
+  g_renderMatrix2D.left   = minX
+  g_renderMatrix2D.bottom = minY
+  g_renderMatrix2D.right  = maxX
+  g_renderMatrix2D.top    = maxY
 
-END SUB
+end sub
+
 
 ' -- Retrieves rendering mode
 FUNCTION Exec_TBGL_GetRenderMatrixMode( ) AS EXT

--- a/src/tbgl_Primitives2D.inc
+++ b/src/tbgl_Primitives2D.inc
@@ -22,6 +22,16 @@
           y1 = b
           x2 = c
           y2 = d
+
+          if g_renderMatrix2d.pixelPerfect then
+            ' -- Ensuring pixel row/column, when needed
+            local xdir, ydir as single
+            xdir = iif(x1 < x2, 1, -1)
+            ydir = iif(y1 < y2, 1, -1)
+            if g_renderMatrix2d.pixelOffsetX*xdir > 0 then x2 += g_renderMatrix2d.pixelOffsetX else x1 += g_renderMatrix2d.pixelOffsetX
+            if g_renderMatrix2d.pixelOffsetY*ydir > 0 then y2 += g_renderMatrix2d.pixelOffsetY else y1 += g_renderMatrix2d.pixelOffsetY
+          end if
+
           glVertex2f x1, y2
           glVertex2f x2, y2
           glVertex2f x2, y1
@@ -82,8 +92,16 @@
 
     nParsed = thinBasic_ParseXNumbers(4,6, a, b, c, d, e, f)
 
-
     IF nParsed < 6 THEN
+
+      if g_Win.RenderMatrixMode = %TBGL_2D and g_renderMatrix2d.pixelPerfect then
+        ' -- Ensure the start and end of the line is visible
+        glBegin %GL_POINTS
+          glVertex2f  a, b
+          glVertex2f  c, d
+        glEnd
+      end if
+
       glBegin %GL_LINES
         glVertex2f  a, b
         glVertex2f  c, d

--- a/src/tbgl_Window.Internal.inc
+++ b/src/tbgl_Window.Internal.inc
@@ -71,6 +71,9 @@ SUB internal_InitOpenGL( )
   resource_Materials_Alloc()
   resource_GBuffers_Alloc()
 
+  ' -- Initializing data
+  resource_Frame_Init()
+
   ' -- Blending
   glBlendFunc %GL_ONE, %GL_ONE
 

--- a/src/thinbasic_TBGL.bas
+++ b/src/thinbasic_TBGL.bas
@@ -9,19 +9,19 @@
 ' -----------------------------------------------------------------------------
 #RESOURCE ICON, PROGRAM, "TBGL.ICO"
 #RESOURCE VERSIONINFO
-#RESOURCE FILEVERSION 1, 10, 6, 0
-#RESOURCE PRODUCTVERSION 1, 10, 6, 0
+#RESOURCE FILEVERSION 1, 10, 6, 1
+#RESOURCE PRODUCTVERSION 1, 10, 6, 1
 
 #RESOURCE STRINGINFO "0409", "04B0"
 
 #RESOURCE VERSION$ "CompanyName",      "thinBasic"
 #RESOURCE VERSION$ "FileDescription",  "thinBASIC module for 2D/3D graphics"
-#RESOURCE VERSION$ "FileVersion",      "1.10.6.0"
+#RESOURCE VERSION$ "FileVersion",      "1.10.6.1"
 #RESOURCE VERSION$ "InternalName",     "TBGL"
 #RESOURCE VERSION$ "OriginalFilename", "ThinBASIC_TBGL.dll"
-#RESOURCE VERSION$ "LegalCopyright",   "Copyright © thinBasic 2018"
+#RESOURCE VERSION$ "LegalCopyright",   "Copyright © thinBasic 2019"
 #RESOURCE VERSION$ "ProductName",      "TBGL"
-#RESOURCE VERSION$ "ProductVersion",   "1.10.6.0"
+#RESOURCE VERSION$ "ProductVersion",   "1.10.6.1"
 #RESOURCE VERSION$ "Comments",         "Support site: http://www.thinbasic.com/"
 
 ' -----------------------------------------------------------------------------
@@ -2097,6 +2097,9 @@ FUNCTION LoadLocalSymbols ALIAS "LoadLocalSymbols" ( OPTIONAL BYVAL sPath AS STR
   thinBasic_AddEquate   "%TBGL_NOT_SRC_AND_DST"    , "" , %GL_AND_INVERTED
   thinBasic_AddEquate   "%TBGL_SRC_OR_NOT_DST"     , "" , %GL_OR_REVERSE
   thinBasic_AddEquate   "%TBGL_NOT_SRC_OR_DST"     , "" , %GL_OR_INVERTED
+
+  thinBasic_AddEquate   "%TBGL_PIXEL_PERFECT_2D"   , "" , %TBGL_PIXEL_PERFECT_2D
+  thinBasic_AddEquate   "%TBGL_OPENGL_ORTHO_2D"    , "" , %TBGL_OPENGL_ORTHO_2D
 
 END FUNCTION
 


### PR DESCRIPTION
Hi Eros,

this is special mode for pixel perfect graphics in TBGL.

You can verify the result via:
```
uses "TBGL"
 
begin const
  %max_x = 400
  %max_y = 300
end const
 
function tbMain()
 
  dword g_win = tbgl_CreateWindowEx ("Pixel perfect 2D rendering - ESC to quit", %max_x, %max_y, 32, %TBGL_WS_WINDOWED or %TBGL_WS_DONTSIZE)
  tbgl_showWindow
  
  long mode = 1
  tbgl_resetKeyState()
  
  while tbgl_isWindow(g_win)
    if tbgl_getWindowKeyState(g_win, %VK_ESCAPE) then exit while
    if tbgl_getWindowKeyState(g_win, %VK_1) then mode = 1
    if tbgl_getWindowKeyState(g_win, %VK_2) then mode = 2
    if tbgl_getWindowKeyState(g_win, %VK_3) then mode = 3
    if tbgl_getWindowKeyState(g_win, %VK_4) then mode = 4
    
    tbgl_setwindowtitle(g_win, "Mode #"+format$(mode))
    select case mode
      case 1
        tbgl_renderMatrix2D (1, %max_y, %max_x, 1, %TBGL_PIXEL_PERFECT_2D)
        
      case 2
        tbgl_renderMatrix2D (1, 1, %max_x, %max_y, %TBGL_PIXEL_PERFECT_2D)
        
      case 3
        tbgl_renderMatrix2D (%max_x, 1, 1, %max_y, %TBGL_PIXEL_PERFECT_2D)
        
      case 4
        tbgl_renderMatrix2D (1, %max_y, %max_x, 1, %TBGL_PIXEL_PERFECT_2D)
        
    end select

    tbgl_clearFrame
 
      draw_test_image()
 
    tbgl_drawFrame

  wend
 
  tbgl_destroyWindow
 
end function
 
function draw_test_image()
  tbgl_pushcolor 255, 0, 0
    tbgl_point (1, 1)
    tbgl_point (%max_x, %max_y)
    tbgl_point (1, %max_y)
    tbgl_point (%max_x, 1)
  tbgl_popColor
  
  tbgl_pushColor 0, 255, 0
    tbgl_line (1, 1, 1, %max_y)
    tbgl_line (1, %max_y, %max_x, %max_y)
    tbgl_line (%max_x, %max_y, %max_x, 1)
    tbgl_line (%max_x, 1, 1, 1)
  tbgl_popColor
end function
```

Try pressing 1, 2, 3, 4 on your keyboard, you should always see the same green border with red pixel in the corners.

This should resolve issue #2 